### PR TITLE
Better error handling and version file logging

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from xml.sax.saxutils import escape
 from jinja2 import Template
 from lxml import etree
@@ -43,3 +44,10 @@ def build_channel_guide(channels, guides):
     xml_declaration = '<?xml version="1.0" encoding="UTF-8"?>'
     channel_guide = f'{xml_declaration}\n{doctype}\n{xml_str}'
     return channel_guide
+
+
+def dump_error(data):
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"logs/{timestamp}.data"
+    with open(filename, "a") as file:
+        file.write(data)

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s [%(levelname)s]: %(message)s',
     handlers=[
-        logging.FileHandler('logs/app.log'),
+        logging.FileHandler(f'logs/v{__version__}.log'),
         logging.StreamHandler()  # Optional: also log to console
     ]
 )

--- a/stb.py
+++ b/stb.py
@@ -7,6 +7,8 @@ import requests.adapters
 from dataclasses import dataclass
 import logging
 
+import helper
+
 
 @dataclass
 class STBProfile:
@@ -106,9 +108,12 @@ class STB:
             sys.exit()
         self.__denied = False
 
-        if not response.text:
-            raise ErrorCodes.InvalidResponseError(f"No response received from. Status code {response.status_code}")
-        data = json.loads(response.text).get('js', None)
+        try:
+            data = json.loads(response.text).get('js', None)
+        except json.JSONDecodeError:
+            helper.dump_error(response.text)
+            raise ErrorCodes.InvalidResponseError("Unable to decode data. Data dumped to file.")
+
         if not isinstance(data, list) and not data:
             raise ErrorCodes.InvalidResponseError()
         return data


### PR DESCRIPTION
Reimplemented error handling for invalid JSON data.
Invalid data is dumped to file in the format of `%Y%m%d_%H%M%S.data`
Logs are now saved by version number in the format of `v1.0.0.log`